### PR TITLE
Update MTU patch to support overlay networks

### DIFF
--- a/src/PatchInstallerService/PackageRoot/MTU_PATCH/MTU_fix.ps1
+++ b/src/PatchInstallerService/PackageRoot/MTU_PATCH/MTU_fix.ps1
@@ -1,12 +1,36 @@
+$overlayinterfaceindices = @()
+$overlaynetworks = @(Get-HNSNetwork | ? {$_.Type -match "Overlay"})
+
+for ($i = 0; $i -lt $overlaynetworks.Length; $i++){
+    if (!$overlaynetworks[$i].NetworkAdapterName) {
+        continue
+    } 
+
+    $adapter = Get-NetAdapter -Name $overlaynetworks[$i].NetworkAdapterName    
+    # Virtual adapter has same MAC address as its corresponding physical adapter
+    $vadapter = Get-NetAdapter | ? {$_.MacAddress -match $adapter.MacAddress -and $_.virtual -eq $true}
+    $overlayinterfaceindices += $vadapter.ifIndex
+}  
+
 Write-Output ("Getting IPv4 interfaces list ...")
 $interfaces = @(Get-NetIPInterface -AddressFamily IPv4)
 
 for ($i = 0; $i -lt $interfaces.Length; $i++) {
-    if ( $interfaces[$i].NlMtu -lt 1500 ) {
-        Write-Output ('Found IPv4 interface named ' + $interfaces[$i].InterfaceAlias + ' with MTU size less than 1500.')
+    # Default MTU size for all non-overlay networks
+    $desiredMTU = 1500     
+    # Used by output message to specify if overlay network
+    $networktypeclarification = ""       
+    # If interface index is in this list, we know the interface is used by an overlay network
+    if ($overlayinterfaceindices.contains($interfaces[$i].ifIndex)) {
+        # Default MTU size for overlay networks
+        $desiredMTU = 1450
+        $networktypeclarification = " used by an overlay network"
+    }
 
+    if ($interfaces[$i].NlMtu -lt $desiredMTU) {
+        Write-Output ('Found IPv4 interface named ' + $interfaces[$i].InterfaceAlias + $networktypeclarification + ' with MTU size less than ' + $desiredMTU + '.')
         Try {
-            $command = 'Set-NetIPInterface -InterfaceIndex ' + $interfaces[$i].InterfaceIndex + ' -NlMtuBytes 1500'
+            $command = 'Set-NetIPInterface -InterfaceIndex ' + $interfaces[$i].InterfaceIndex + ' -NlMtuBytes ' + $desiredMTU
             Write-Output ('Executing command ' + $command)
             Invoke-Expression -Command $command
         }

--- a/src/PatchInstallerService/PackageRoot/MTU_PATCH/MTU_fix.ps1
+++ b/src/PatchInstallerService/PackageRoot/MTU_PATCH/MTU_fix.ps1
@@ -2,7 +2,9 @@ $overlayinterfaceindices = @()
 $overlaynetworks = @(Get-HNSNetwork | ? {$_.Type -match "Overlay"})
 
 for ($i = 0; $i -lt $overlaynetworks.Length; $i++){
-    if (!$overlaynetworks[$i].NetworkAdapterName) {
+    # Get a list of ids of interfaces that belong to an overlay network. 
+	# This is done by first getting the adapters for an overlay network and then finding all the interfaces used by those adapters.
+	if (!$overlaynetworks[$i].NetworkAdapterName) {
         continue
     } 
 
@@ -16,13 +18,13 @@ Write-Output ("Getting IPv4 interfaces list ...")
 $interfaces = @(Get-NetIPInterface -AddressFamily IPv4)
 
 for ($i = 0; $i -lt $interfaces.Length; $i++) {
-    # Default MTU size for all non-overlay networks
+    # Default MTU size for a non-overlay network interface
     $desiredMTU = 1500     
     # Used by output message to specify if overlay network
     $networktypeclarification = ""       
-    # If interface index is in this list, we know the interface is used by an overlay network
+    # If an interface index is in this list, we know that interface is used by an overlay network
     if ($overlayinterfaceindices.contains($interfaces[$i].ifIndex)) {
-        # Default MTU size for overlay networks
+        # Default MTU size for an overlay network interface
         $desiredMTU = 1450
         $networktypeclarification = " used by an overlay network"
     }
@@ -30,7 +32,7 @@ for ($i = 0; $i -lt $interfaces.Length; $i++) {
     if ($interfaces[$i].NlMtu -lt $desiredMTU) {
         Write-Output ('Found IPv4 interface named ' + $interfaces[$i].InterfaceAlias + $networktypeclarification + ' with MTU size less than ' + $desiredMTU + '.')
         Try {
-            $command = 'Set-NetIPInterface -InterfaceIndex ' + $interfaces[$i].InterfaceIndex + ' -NlMtuBytes ' + $desiredMTU
+            $command = 'Set-NetIPInterface -InterfaceIndex ' + $interfaces[$i].InterfaceIndex + ' -AddressFamily IPv4 -NlMtuBytes ' + $desiredMTU
             Write-Output ('Executing command ' + $command)
             Invoke-Expression -Command $command
         }

--- a/src/PatchInstallerService/PackageRoot/MTU_PATCH/MTU_fix.ps1
+++ b/src/PatchInstallerService/PackageRoot/MTU_PATCH/MTU_fix.ps1
@@ -3,8 +3,8 @@ $overlaynetworks = @(Get-HNSNetwork | ? {$_.Type -match "Overlay"})
 
 for ($i = 0; $i -lt $overlaynetworks.Length; $i++){
     # Get a list of ids of interfaces that belong to an overlay network. 
-	# This is done by first getting the adapters for an overlay network and then finding all the interfaces used by those adapters.
-	if (!$overlaynetworks[$i].NetworkAdapterName) {
+    # This is done by first getting the adapters for an overlay network and then finding all the interfaces used by those adapters.
+    if (!$overlaynetworks[$i].NetworkAdapterName) {
         continue
     } 
 

--- a/src/PatchInstallerService/PackageRoot/MTU_PATCH/README.md
+++ b/src/PatchInstallerService/PackageRoot/MTU_PATCH/README.md
@@ -5,10 +5,4 @@ author: ninzavivek
 ---
 
 ## About this Patch
-The purpose of this patch is to ensure that the MTU size of each IPv4 interface on a cluster node is set correctly. 
-
-The MTU size of an interface programmed inside a Windows Container (NAT Networking mode) is set to 1500 bytes. MTU size mismatch between a Windows Container's interface and an IPv4 interface leads to fragmentation, which could cause choppy connections in some cases. However, an overlay network packet has an additional 50 bytes in its header. Therefore, an interface that belongs to an overlay network should have its MTU size set to 1450 and the MTU size of any other interface should be set to 1500.     
-
-This patch starts by building a list of IDs of interfaces that belong to overlay networks. It then queries for all IPv4 interfaces on a cluster node. Using the list of IDs, it checks if an interface belongs to an overlay network or not to determine if the desired MTU size is 1450 or 1500. It then checks if the MTU size is set to less than the desired size. If this is true, it will reset the MTU value of the interface to the correct size.
-
-Please note, this patch is only supposed to deployed on Service Fabric Clusters that have L2 tunnel network setup and have Windows container with only NAT networking mode configured.
+The purpose of this patch is to ensure that the MTU size of each IPv4 interface on a cluster node is set correctly based on the type of container network it is used for. 

--- a/src/PatchInstallerService/PackageRoot/MTU_PATCH/README.md
+++ b/src/PatchInstallerService/PackageRoot/MTU_PATCH/README.md
@@ -5,4 +5,6 @@ author: ninzavivek
 ---
 
 ## About this Patch
-The purpose of this patch is to ensure that the MTU size of each IPv4 interface on a cluster node is set correctly based on the type of container network it is used for. 
+The purpose of this patch is to ensure that the MTU size of each IPv4 interface on a cluster node is set correctly based on the type of container network it is used for.
+
+For most interfaces, the MTU size should be set to 1500 bytes to match the MTU size of an interface programmed inside a Windows Container (NAT Networking mode). MTU size mismatch leads to fragmentation, which could cause choppy connections in some cases. An interface that belongs to an overlay network should have its MTU size set to 1450 because an overlay network packet has an additional 50 bytes in its header.

--- a/src/PatchInstallerService/PackageRoot/MTU_PATCH/README.md
+++ b/src/PatchInstallerService/PackageRoot/MTU_PATCH/README.md
@@ -7,7 +7,7 @@ author: ninzavivek
 ## About this Patch
 The purpose of this patch is to ensure that the MTU size of each IPv4 interface on a cluster node is set correctly. 
 
-The MTU size of an interface programmed inside a Windows Container (NAT Networking mode) is set to 1500 bytes. MTU size mismatch between that interface and any of the IPv4 interfaces leads to fragmentation, which could cause choppy connections in some cases. However, an overlay network packet has an additional 50 bytes in its header. Therefore, an interface that belongs to an overlay network should have its MTU size set to 1450 and the MTU size of any other interface should be set to 1500.     
+The MTU size of an interface programmed inside a Windows Container (NAT Networking mode) is set to 1500 bytes. MTU size mismatch between a Windows Container's interface and any of the IPv4 interfaces leads to fragmentation, which could cause choppy connections in some cases. However, an overlay network packet has an additional 50 bytes in its header. Therefore, an interface that belongs to an overlay network should have its MTU size set to 1450 and the MTU size of any other interface should be set to 1500.     
 
 This patch starts by building a list of IDs of interfaces that belong to overlay networks. It then queries for all IPv4 interfaces on a cluster node. Using the list of IDs, it checks if an interface belongs to an overlay network or not to determine if the desired MTU size is 1450 or 1500. It then checks if the MTU size is set to less than the desired size. If this is true, it will reset the MTU value of the interface to the correct size.
 

--- a/src/PatchInstallerService/PackageRoot/MTU_PATCH/README.md
+++ b/src/PatchInstallerService/PackageRoot/MTU_PATCH/README.md
@@ -7,7 +7,7 @@ author: ninzavivek
 ## About this Patch
 The purpose of this patch is to ensure that the MTU size of each IPv4 interface on a cluster node is set correctly. 
 
-The MTU size of an interface programmed inside a Windows Container (NAT Networking mode) is set to 1500 bytes. MTU size mismatch between a Windows Container's interface and any of the IPv4 interfaces leads to fragmentation, which could cause choppy connections in some cases. However, an overlay network packet has an additional 50 bytes in its header. Therefore, an interface that belongs to an overlay network should have its MTU size set to 1450 and the MTU size of any other interface should be set to 1500.     
+The MTU size of an interface programmed inside a Windows Container (NAT Networking mode) is set to 1500 bytes. MTU size mismatch between a Windows Container's interface and an IPv4 interface leads to fragmentation, which could cause choppy connections in some cases. However, an overlay network packet has an additional 50 bytes in its header. Therefore, an interface that belongs to an overlay network should have its MTU size set to 1450 and the MTU size of any other interface should be set to 1500.     
 
 This patch starts by building a list of IDs of interfaces that belong to overlay networks. It then queries for all IPv4 interfaces on a cluster node. Using the list of IDs, it checks if an interface belongs to an overlay network or not to determine if the desired MTU size is 1450 or 1500. It then checks if the MTU size is set to less than the desired size. If this is true, it will reset the MTU value of the interface to the correct size.
 

--- a/src/PatchInstallerService/PackageRoot/MTU_PATCH/README.md
+++ b/src/PatchInstallerService/PackageRoot/MTU_PATCH/README.md
@@ -5,6 +5,10 @@ author: ninzavivek
 ---
 
 ## About this Patch
-This patch queries for IPv4 interfaces on a cluster node that have MTU size set less than 1500 bytes. If it finds one, it will reset the MTU value to 1500 for the interface. This is done in order to match the MTU size set on an interface programmed inside a Windows Container (NAT Networking mode). MTU size mismatch leads to fragmentation which could cause choppy connections in some cases.
+The purpose of this patch is to ensure that the MTU size of each IPv4 interface on a cluster node is set correctly. 
+
+The MTU size of an interface programmed inside a Windows Container (NAT Networking mode) is set to 1500 bytes. MTU size mismatch between that interface and any of the IPv4 interfaces leads to fragmentation, which could cause choppy connections in some cases. However, an overlay network packet has an additional 50 bytes in its header. Therefore, an interface that belongs to an overlay network should have its MTU size set to 1450 and the MTU size of any other interface should be set to 1500.     
+
+This patch starts by building a list of IDs of interfaces that belong to overlay networks. It then queries for all IPv4 interfaces on a cluster node. Using the list of IDs, it checks if an interface belongs to an overlay network or not to determine if the desired MTU size is 1450 or 1500. It then checks if the MTU size is set to less than the desired size. If this is true, it will reset the MTU value of the interface to the correct size.
 
 Please note, this patch is only supposed to deployed on Service Fabric Clusters that have L2 tunnel network setup and have Windows container with only NAT networking mode configured.

--- a/src/PatchInstallerService/PackageRoot/MTU_PATCH/verify.ps1
+++ b/src/PatchInstallerService/PackageRoot/MTU_PATCH/verify.ps1
@@ -2,8 +2,8 @@ $overlayinterfaceindices = @()
 $overlaynetworks = @(Get-HNSNetwork | ? {$_.Type -match "Overlay"})
 
 for ($i = 0; $i -lt $overlaynetworks.Length; $i++){
-	# Get a list of ids of interfaces that belong to an overlay network. 
-	# This is done by first getting the adapters for an overlay network and then finding all the interfaces used by those adapters.
+    # Get a list of ids of interfaces that belong to an overlay network. 
+    # This is done by first getting the adapters for an overlay network and then finding all the interfaces used by those adapters.
     if (!$overlaynetworks[$i].NetworkAdapterName) {
         continue
     } 

--- a/src/PatchInstallerService/PackageRoot/MTU_PATCH/verify.ps1
+++ b/src/PatchInstallerService/PackageRoot/MTU_PATCH/verify.ps1
@@ -1,2 +1,33 @@
-$interfaces = @(Get-NetIPInterface -AddressFamily IPv4 | ? {$_.NlMtu -lt 1500}).Count
-exit $interfaces
+$overlayinterfaceindices = @()
+$overlaynetworks = @(Get-HNSNetwork | ? {$_.Type -match "Overlay"})
+
+for ($i = 0; $i -lt $overlaynetworks.Length; $i++){
+    if (!$overlaynetworks[$i].NetworkAdapterName) {
+        continue
+    } 
+
+    $adapter = Get-NetAdapter -Name $overlaynetworks[$i].NetworkAdapterName    
+    # Virtual adapter has same MAC address as its corresponding physical adapter
+    $vadapter = Get-NetAdapter | ? {$_.MacAddress -match $adapter.MacAddress -and $_.virtual -eq $true}
+    $overlayinterfaceindices += $vadapter.ifIndex
+}  
+
+Write-Output ("Getting IPv4 interfaces list ...")
+$interfaces = @(Get-NetIPInterface -AddressFamily IPv4)
+
+$numbadinterfaces = 0
+for ($i = 0; $i -lt $interfaces.Length; $i++) {   
+    # Default MTU size for all non-overlay networks
+    $desiredMTU = 1500        
+    # If interface index is in this list, we know the interface is used by an overlay network
+    if ($overlayinterfaceindices.contains($interfaces[$i].ifIndex)) {
+        # Default MTU size for overlay networks
+        $desiredMTU = 1450
+    }
+
+    if ($interfaces[$i].NlMtu -lt $desiredMTU) {
+        $numbadinterfaces++
+    }
+}
+
+exit $numbadinterfaces

--- a/src/PatchInstallerService/PackageRoot/MTU_PATCH/verify.ps1
+++ b/src/PatchInstallerService/PackageRoot/MTU_PATCH/verify.ps1
@@ -2,6 +2,8 @@ $overlayinterfaceindices = @()
 $overlaynetworks = @(Get-HNSNetwork | ? {$_.Type -match "Overlay"})
 
 for ($i = 0; $i -lt $overlaynetworks.Length; $i++){
+	# Get a list of ids of interfaces that belong to an overlay network. 
+	# This is done by first getting the adapters for an overlay network and then finding all the interfaces used by those adapters.
     if (!$overlaynetworks[$i].NetworkAdapterName) {
         continue
     } 
@@ -17,11 +19,11 @@ $interfaces = @(Get-NetIPInterface -AddressFamily IPv4)
 
 $numbadinterfaces = 0
 for ($i = 0; $i -lt $interfaces.Length; $i++) {   
-    # Default MTU size for all non-overlay networks
+    # Default MTU size for a non-overlay network interface
     $desiredMTU = 1500        
-    # If interface index is in this list, we know the interface is used by an overlay network
+    # If an interface index is in this list, we know that interface is used by an overlay network
     if ($overlayinterfaceindices.contains($interfaces[$i].ifIndex)) {
-        # Default MTU size for overlay networks
+        # Default MTU size for an overlay network interface
         $desiredMTU = 1450
     }
 


### PR DESCRIPTION
Change MTU fix to take into account that the MTU size of an interface that belongs to an overlay network should be set to 1450 bytes. See README for more information.